### PR TITLE
Add CI badge to show build status

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,10 @@
 #+TODO: TODO INPROGRESS | DONE
 #+PRIORITY: A E C
+* NDP
+[[https://fortlogic.visualstudio.com/NDP/NDP%20Team/_build?definitionId=3][file:https://fortlogic.visualstudio.com/NDP/_apis/build/status/NDP-develop?.svg]]
+
+FPGA based computer inspired by the C128, PDP-11, and Macintosh
+
 * TODOs
 ** Neccesities
 *** INPROGRESS [#C] Actually write a proper README


### PR DESCRIPTION
I've built a lovely CI pipeline to automagically build NDP (and generate the vhdl/verilog), and added the badge for the 'develop' branch to the readme.